### PR TITLE
Remove redundant navigation brand text

### DIFF
--- a/about.html
+++ b/about.html
@@ -203,11 +203,9 @@
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
             <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-3">
+                <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <div class="font-display text-2xl font-bold text-gradient">
-                        Sakura Ramen
-                    </div>
+                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">

--- a/contact.html
+++ b/contact.html
@@ -200,11 +200,9 @@
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
             <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-3">
+                <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <div class="font-display text-2xl font-bold text-gradient">
-                        Sakura Ramen
-                    </div>
+                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">

--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
             <div class="flex items-center justify-between">
                 <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
+                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">

--- a/menu.html
+++ b/menu.html
@@ -199,11 +199,9 @@
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
             <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-3">
+                <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <div class="font-display text-2xl font-bold text-gradient">
-                        Sakura Ramen
-                    </div>
+                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- remove the duplicate "Sakura Ramen" wordmark next to the navigation logo on every page
- add screen-reader-only branding text so the site remains accessible without displaying redundant copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3043a9cec832b8f259c5bf31ab045