### PR TITLE
Add demo chatbot widget across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -90,12 +90,187 @@
             opacity: 1;
             transform: translateY(0);
         }
-        
+
         .stagger-item {
             opacity: 0;
             transform: translateY(20px);
         }
-        
+
+        .chatbot-widget {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            z-index: 60;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 0.75rem;
+        }
+
+        .chatbot-toggle {
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 9999px;
+            border: none;
+            background: linear-gradient(135deg, var(--sakura-pink) 0%, #E8B4B8 100%);
+            color: var(--charcoal);
+            box-shadow: 0 20px 45px rgba(244, 194, 194, 0.35);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .chatbot-toggle:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 24px 50px rgba(244, 194, 194, 0.45);
+        }
+
+        .chatbot-widget.chatbot-open .chatbot-toggle {
+            box-shadow: 0 12px 30px rgba(44, 44, 44, 0.2);
+        }
+
+        .chatbot-window {
+            width: min(22rem, calc(100vw - 2.5rem));
+            max-height: 28rem;
+            background: var(--warm-white);
+            border-radius: 1.25rem;
+            box-shadow: 0 25px 60px rgba(44, 44, 44, 0.18);
+            border: 1px solid rgba(244, 194, 194, 0.4);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .chatbot-header {
+            padding: 1rem 1.25rem;
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.25) 0%, rgba(143, 188, 143, 0.15) 100%);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .chatbot-header h3 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .chatbot-header p {
+            margin: 0;
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+        }
+
+        .chatbot-close {
+            background: transparent;
+            border: none;
+            color: var(--charcoal);
+            cursor: pointer;
+            border-radius: 9999px;
+            width: 2rem;
+            height: 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background-color 0.2s ease;
+        }
+
+        .chatbot-close:hover {
+            background-color: rgba(244, 194, 194, 0.25);
+        }
+
+        .chatbot-body {
+            padding: 1.25rem;
+            overflow-y: auto;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .chatbot-message {
+            display: flex;
+            gap: 0.75rem;
+            align-items: flex-start;
+        }
+
+        .chatbot-message--bot .chatbot-bubble {
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.35) 0%, rgba(143, 188, 143, 0.2) 100%);
+            color: var(--charcoal);
+        }
+
+        .chatbot-bubble {
+            padding: 0.85rem 1rem;
+            border-radius: 1rem;
+            background: rgba(44, 44, 44, 0.85);
+            color: white;
+            font-size: 0.95rem;
+            line-height: 1.4;
+            flex: 1;
+        }
+
+        .chatbot-avatar {
+            width: 2rem;
+            height: 2rem;
+            border-radius: 9999px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: white;
+            box-shadow: 0 10px 20px rgba(244, 194, 194, 0.4);
+            font-size: 1.2rem;
+        }
+
+        .chatbot-message--note {
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+            text-align: center;
+        }
+
+        .chatbot-footer {
+            padding: 1rem 1.25rem;
+            border-top: 1px solid rgba(244, 194, 194, 0.4);
+            background: rgba(254, 254, 254, 0.95);
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .chatbot-input {
+            flex: 1;
+            border: 1px solid rgba(44, 44, 44, 0.1);
+            border-radius: 9999px;
+            padding: 0.75rem 1rem;
+            font-size: 0.95rem;
+            background-color: rgba(248, 248, 248, 0.8);
+            color: var(--medium-gray);
+        }
+
+        .chatbot-send {
+            border: none;
+            background: var(--charcoal);
+            color: white;
+            border-radius: 9999px;
+            padding: 0.6rem 1.1rem;
+            font-size: 0.9rem;
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
+        @media (max-width: 640px) {
+            .chatbot-widget {
+                right: 1rem;
+                bottom: 1rem;
+            }
+
+            .chatbot-window {
+                width: min(20rem, calc(100vw - 2rem));
+            }
+        }
+
         .hero-about {
             background: linear-gradient(135deg, rgba(244, 194, 194, 0.1) 0%, rgba(143, 188, 143, 0.1) 100%);
             position: relative;
@@ -471,6 +646,42 @@
             </div>
         </div>
     </footer>
+
+    <div class="chatbot-widget" aria-live="polite">
+        <button class="chatbot-toggle" type="button" aria-label="Open Sakura Ramen chat" aria-expanded="false" aria-controls="chatbot-window">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h6m9 0a9 9 0 11-18 0 9 9 0 0118 0zm-5 5l4 2-1-3" />
+            </svg>
+        </button>
+        <div class="chatbot-window" id="chatbot-window" role="dialog" aria-modal="false" aria-label="Sakura Ramen virtual concierge" hidden>
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="font-display">Virtual Concierge</h3>
+                    <p>Live chat is coming soon.</p>
+                </div>
+                <button class="chatbot-close" type="button" aria-label="Close chat window">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message chatbot-message--bot">
+                    <span class="chatbot-avatar" aria-hidden="true">🍜</span>
+                    <div class="chatbot-bubble">
+                        Kon'nichiwa! I'm the Sakura Ramen concierge. Our interactive chat will be launching soon, but I'm here to guide you through the highlights while you explore.
+                    </div>
+                </div>
+                <div class="chatbot-message chatbot-message--note">
+                    Demo preview: conversational support will be activated after integration.
+                </div>
+            </div>
+            <div class="chatbot-footer">
+                <input class="chatbot-input" type="text" placeholder="Chat support coming soon" disabled>
+                <button class="chatbot-send" type="button" disabled>Send</button>
+            </div>
+        </div>
+    </div>
 
     <!-- JavaScript -->
     <script src="main.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -268,6 +268,181 @@
             z-index: 2;
         }
 
+        .chatbot-widget {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            z-index: 60;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 0.75rem;
+        }
+
+        .chatbot-toggle {
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 9999px;
+            border: none;
+            background: linear-gradient(135deg, var(--sakura-pink) 0%, #E8B4B8 100%);
+            color: var(--charcoal);
+            box-shadow: 0 20px 45px rgba(244, 194, 194, 0.35);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .chatbot-toggle:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 24px 50px rgba(244, 194, 194, 0.45);
+        }
+
+        .chatbot-widget.chatbot-open .chatbot-toggle {
+            box-shadow: 0 12px 30px rgba(44, 44, 44, 0.2);
+        }
+
+        .chatbot-window {
+            width: min(22rem, calc(100vw - 2.5rem));
+            max-height: 28rem;
+            background: var(--warm-white);
+            border-radius: 1.25rem;
+            box-shadow: 0 25px 60px rgba(44, 44, 44, 0.18);
+            border: 1px solid rgba(244, 194, 194, 0.4);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .chatbot-header {
+            padding: 1rem 1.25rem;
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.25) 0%, rgba(143, 188, 143, 0.15) 100%);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .chatbot-header h3 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .chatbot-header p {
+            margin: 0;
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+        }
+
+        .chatbot-close {
+            background: transparent;
+            border: none;
+            color: var(--charcoal);
+            cursor: pointer;
+            border-radius: 9999px;
+            width: 2rem;
+            height: 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background-color 0.2s ease;
+        }
+
+        .chatbot-close:hover {
+            background-color: rgba(244, 194, 194, 0.25);
+        }
+
+        .chatbot-body {
+            padding: 1.25rem;
+            overflow-y: auto;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .chatbot-message {
+            display: flex;
+            gap: 0.75rem;
+            align-items: flex-start;
+        }
+
+        .chatbot-message--bot .chatbot-bubble {
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.35) 0%, rgba(143, 188, 143, 0.2) 100%);
+            color: var(--charcoal);
+        }
+
+        .chatbot-bubble {
+            padding: 0.85rem 1rem;
+            border-radius: 1rem;
+            background: rgba(44, 44, 44, 0.85);
+            color: white;
+            font-size: 0.95rem;
+            line-height: 1.4;
+            flex: 1;
+        }
+
+        .chatbot-avatar {
+            width: 2rem;
+            height: 2rem;
+            border-radius: 9999px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: white;
+            box-shadow: 0 10px 20px rgba(244, 194, 194, 0.4);
+            font-size: 1.2rem;
+        }
+
+        .chatbot-message--note {
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+            text-align: center;
+        }
+
+        .chatbot-footer {
+            padding: 1rem 1.25rem;
+            border-top: 1px solid rgba(244, 194, 194, 0.4);
+            background: rgba(254, 254, 254, 0.95);
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .chatbot-input {
+            flex: 1;
+            border: 1px solid rgba(44, 44, 44, 0.1);
+            border-radius: 9999px;
+            padding: 0.75rem 1rem;
+            font-size: 0.95rem;
+            background-color: rgba(248, 248, 248, 0.8);
+            color: var(--medium-gray);
+        }
+
+        .chatbot-send {
+            border: none;
+            background: var(--charcoal);
+            color: white;
+            border-radius: 9999px;
+            padding: 0.6rem 1.1rem;
+            font-size: 0.9rem;
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
+        @media (max-width: 640px) {
+            .chatbot-widget {
+                right: 1rem;
+                bottom: 1rem;
+            }
+
+            .chatbot-window {
+                width: min(20rem, calc(100vw - 2rem));
+            }
+        }
+
         /* Logo styling */
         .logo {
             display: block;
@@ -534,6 +709,42 @@
             </div>
         </div>
     </footer>
+
+    <div class="chatbot-widget" aria-live="polite">
+        <button class="chatbot-toggle" type="button" aria-label="Open Sakura Ramen chat" aria-expanded="false" aria-controls="chatbot-window">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h6m9 0a9 9 0 11-18 0 9 9 0 0118 0zm-5 5l4 2-1-3" />
+            </svg>
+        </button>
+        <div class="chatbot-window" id="chatbot-window" role="dialog" aria-modal="false" aria-label="Sakura Ramen virtual concierge" hidden>
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="font-display">Virtual Concierge</h3>
+                    <p>Live chat is coming soon.</p>
+                </div>
+                <button class="chatbot-close" type="button" aria-label="Close chat window">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message chatbot-message--bot">
+                    <span class="chatbot-avatar" aria-hidden="true">🍜</span>
+                    <div class="chatbot-bubble">
+                        Kon'nichiwa! I'm the Sakura Ramen concierge. Our interactive chat will be launching soon, but I'm here to guide you through the highlights while you explore.
+                    </div>
+                </div>
+                <div class="chatbot-message chatbot-message--note">
+                    Demo preview: conversational support will be activated after integration.
+                </div>
+            </div>
+            <div class="chatbot-footer">
+                <input class="chatbot-input" type="text" placeholder="Chat support coming soon" disabled>
+                <button class="chatbot-send" type="button" disabled>Send</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Success Modal -->
     <div id="success-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden">

--- a/index.html
+++ b/index.html
@@ -160,7 +160,182 @@
             position: relative;
             z-index: 2;
         }
-        
+
+        .chatbot-widget {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            z-index: 60;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 0.75rem;
+        }
+
+        .chatbot-toggle {
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 9999px;
+            border: none;
+            background: linear-gradient(135deg, var(--sakura-pink) 0%, #E8B4B8 100%);
+            color: var(--charcoal);
+            box-shadow: 0 20px 45px rgba(244, 194, 194, 0.35);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .chatbot-toggle:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 24px 50px rgba(244, 194, 194, 0.45);
+        }
+
+        .chatbot-widget.chatbot-open .chatbot-toggle {
+            box-shadow: 0 12px 30px rgba(44, 44, 44, 0.2);
+        }
+
+        .chatbot-window {
+            width: min(22rem, calc(100vw - 2.5rem));
+            max-height: 28rem;
+            background: var(--warm-white);
+            border-radius: 1.25rem;
+            box-shadow: 0 25px 60px rgba(44, 44, 44, 0.18);
+            border: 1px solid rgba(244, 194, 194, 0.4);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .chatbot-header {
+            padding: 1rem 1.25rem;
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.25) 0%, rgba(143, 188, 143, 0.15) 100%);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .chatbot-header h3 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .chatbot-header p {
+            margin: 0;
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+        }
+
+        .chatbot-close {
+            background: transparent;
+            border: none;
+            color: var(--charcoal);
+            cursor: pointer;
+            border-radius: 9999px;
+            width: 2rem;
+            height: 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background-color 0.2s ease;
+        }
+
+        .chatbot-close:hover {
+            background-color: rgba(244, 194, 194, 0.25);
+        }
+
+        .chatbot-body {
+            padding: 1.25rem;
+            overflow-y: auto;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .chatbot-message {
+            display: flex;
+            gap: 0.75rem;
+            align-items: flex-start;
+        }
+
+        .chatbot-message--bot .chatbot-bubble {
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.35) 0%, rgba(143, 188, 143, 0.2) 100%);
+            color: var(--charcoal);
+        }
+
+        .chatbot-bubble {
+            padding: 0.85rem 1rem;
+            border-radius: 1rem;
+            background: rgba(44, 44, 44, 0.85);
+            color: white;
+            font-size: 0.95rem;
+            line-height: 1.4;
+            flex: 1;
+        }
+
+        .chatbot-avatar {
+            width: 2rem;
+            height: 2rem;
+            border-radius: 9999px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: white;
+            box-shadow: 0 10px 20px rgba(244, 194, 194, 0.4);
+            font-size: 1.2rem;
+        }
+
+        .chatbot-message--note {
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+            text-align: center;
+        }
+
+        .chatbot-footer {
+            padding: 1rem 1.25rem;
+            border-top: 1px solid rgba(244, 194, 194, 0.4);
+            background: rgba(254, 254, 254, 0.95);
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .chatbot-input {
+            flex: 1;
+            border: 1px solid rgba(44, 44, 44, 0.1);
+            border-radius: 9999px;
+            padding: 0.75rem 1rem;
+            font-size: 0.95rem;
+            background-color: rgba(248, 248, 248, 0.8);
+            color: var(--medium-gray);
+        }
+
+        .chatbot-send {
+            border: none;
+            background: var(--charcoal);
+            color: white;
+            border-radius: 9999px;
+            padding: 0.6rem 1.1rem;
+            font-size: 0.9rem;
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
+        @media (max-width: 640px) {
+            .chatbot-widget {
+                right: 1rem;
+                bottom: 1rem;
+            }
+
+            .chatbot-window {
+                width: min(20rem, calc(100vw - 2rem));
+            }
+        }
+
         /* Logo styling */
         .logo {
             display: block;
@@ -449,6 +624,42 @@
             </div>
         </div>
     </footer>
+
+    <div class="chatbot-widget" aria-live="polite">
+        <button class="chatbot-toggle" type="button" aria-label="Open Sakura Ramen chat" aria-expanded="false" aria-controls="chatbot-window">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h6m9 0a9 9 0 11-18 0 9 9 0 0118 0zm-5 5l4 2-1-3" />
+            </svg>
+        </button>
+        <div class="chatbot-window" id="chatbot-window" role="dialog" aria-modal="false" aria-label="Sakura Ramen virtual concierge" hidden>
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="font-display">Virtual Concierge</h3>
+                    <p>Live chat is coming soon.</p>
+                </div>
+                <button class="chatbot-close" type="button" aria-label="Close chat window">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message chatbot-message--bot">
+                    <span class="chatbot-avatar" aria-hidden="true">🍜</span>
+                    <div class="chatbot-bubble">
+                        Kon'nichiwa! I'm the Sakura Ramen concierge. Our interactive chat will be launching soon, but I'm here to guide you through the highlights while you explore.
+                    </div>
+                </div>
+                <div class="chatbot-message chatbot-message--note">
+                    Demo preview: conversational support will be activated after integration.
+                </div>
+            </div>
+            <div class="chatbot-footer">
+                <input class="chatbot-input" type="text" placeholder="Chat support coming soon" disabled>
+                <button class="chatbot-send" type="button" disabled>Send</button>
+            </div>
+        </div>
+    </div>
 
     <!-- JavaScript -->
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeScrollAnimations();
     initializeCartFunctionality();
     initializeTextAnimations();
+    initializeChatbot();
 });
 
 // Navigation functionality
@@ -116,6 +117,59 @@ function initializeTextAnimations() {
             });
         }
     }
+}
+
+function initializeChatbot() {
+    const widget = document.querySelector('.chatbot-widget');
+    if (!widget) return;
+
+    const toggleButton = widget.querySelector('.chatbot-toggle');
+    const closeButton = widget.querySelector('.chatbot-close');
+    const chatWindow = widget.querySelector('.chatbot-window');
+    const messageInput = widget.querySelector('.chatbot-input');
+
+    if (!toggleButton || !chatWindow) return;
+
+    const openChat = () => {
+        chatWindow.hidden = false;
+        widget.classList.add('chatbot-open');
+        toggleButton.setAttribute('aria-expanded', 'true');
+        if (messageInput && !messageInput.disabled) {
+            messageInput.focus({ preventScroll: true });
+        }
+    };
+
+    const closeChat = () => {
+        chatWindow.hidden = true;
+        widget.classList.remove('chatbot-open');
+        toggleButton.setAttribute('aria-expanded', 'false');
+        toggleButton.focus({ preventScroll: true });
+    };
+
+    toggleButton.addEventListener('click', () => {
+        if (chatWindow.hidden) {
+            openChat();
+        } else {
+            closeChat();
+        }
+    });
+
+    if (closeButton) {
+        closeButton.addEventListener('click', closeChat);
+    }
+
+    document.addEventListener('click', event => {
+        if (!widget.contains(event.target) && !chatWindow.hidden) {
+            closeChat();
+        }
+    });
+
+    widget.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && !chatWindow.hidden) {
+            event.stopPropagation();
+            closeChat();
+        }
+    });
 }
 
 // Menu filtering functionality

--- a/menu.html
+++ b/menu.html
@@ -104,7 +104,182 @@
             opacity: 0;
             transform: translateY(20px);
         }
-        
+
+        .chatbot-widget {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            z-index: 60;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 0.75rem;
+        }
+
+        .chatbot-toggle {
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 9999px;
+            border: none;
+            background: linear-gradient(135deg, var(--sakura-pink) 0%, #E8B4B8 100%);
+            color: var(--charcoal);
+            box-shadow: 0 20px 45px rgba(244, 194, 194, 0.35);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .chatbot-toggle:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 24px 50px rgba(244, 194, 194, 0.45);
+        }
+
+        .chatbot-widget.chatbot-open .chatbot-toggle {
+            box-shadow: 0 12px 30px rgba(44, 44, 44, 0.2);
+        }
+
+        .chatbot-window {
+            width: min(22rem, calc(100vw - 2.5rem));
+            max-height: 28rem;
+            background: var(--warm-white);
+            border-radius: 1.25rem;
+            box-shadow: 0 25px 60px rgba(44, 44, 44, 0.18);
+            border: 1px solid rgba(244, 194, 194, 0.4);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .chatbot-header {
+            padding: 1rem 1.25rem;
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.25) 0%, rgba(143, 188, 143, 0.15) 100%);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .chatbot-header h3 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .chatbot-header p {
+            margin: 0;
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+        }
+
+        .chatbot-close {
+            background: transparent;
+            border: none;
+            color: var(--charcoal);
+            cursor: pointer;
+            border-radius: 9999px;
+            width: 2rem;
+            height: 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background-color 0.2s ease;
+        }
+
+        .chatbot-close:hover {
+            background-color: rgba(244, 194, 194, 0.25);
+        }
+
+        .chatbot-body {
+            padding: 1.25rem;
+            overflow-y: auto;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .chatbot-message {
+            display: flex;
+            gap: 0.75rem;
+            align-items: flex-start;
+        }
+
+        .chatbot-message--bot .chatbot-bubble {
+            background: linear-gradient(135deg, rgba(244, 194, 194, 0.35) 0%, rgba(143, 188, 143, 0.2) 100%);
+            color: var(--charcoal);
+        }
+
+        .chatbot-bubble {
+            padding: 0.85rem 1rem;
+            border-radius: 1rem;
+            background: rgba(44, 44, 44, 0.85);
+            color: white;
+            font-size: 0.95rem;
+            line-height: 1.4;
+            flex: 1;
+        }
+
+        .chatbot-avatar {
+            width: 2rem;
+            height: 2rem;
+            border-radius: 9999px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: white;
+            box-shadow: 0 10px 20px rgba(244, 194, 194, 0.4);
+            font-size: 1.2rem;
+        }
+
+        .chatbot-message--note {
+            font-size: 0.85rem;
+            color: var(--medium-gray);
+            text-align: center;
+        }
+
+        .chatbot-footer {
+            padding: 1rem 1.25rem;
+            border-top: 1px solid rgba(244, 194, 194, 0.4);
+            background: rgba(254, 254, 254, 0.95);
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .chatbot-input {
+            flex: 1;
+            border: 1px solid rgba(44, 44, 44, 0.1);
+            border-radius: 9999px;
+            padding: 0.75rem 1rem;
+            font-size: 0.95rem;
+            background-color: rgba(248, 248, 248, 0.8);
+            color: var(--medium-gray);
+        }
+
+        .chatbot-send {
+            border: none;
+            background: var(--charcoal);
+            color: white;
+            border-radius: 9999px;
+            padding: 0.6rem 1.1rem;
+            font-size: 0.9rem;
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
+        @media (max-width: 640px) {
+            .chatbot-widget {
+                right: 1rem;
+                bottom: 1rem;
+            }
+
+            .chatbot-window {
+                width: min(20rem, calc(100vw - 2rem));
+            }
+        }
+
         /* Mobile optimizations */
         @media (max-width: 768px) {
             .card-hover:hover {
@@ -483,6 +658,42 @@
             </div>
         </div>
     </footer>
+
+    <div class="chatbot-widget" aria-live="polite">
+        <button class="chatbot-toggle" type="button" aria-label="Open Sakura Ramen chat" aria-expanded="false" aria-controls="chatbot-window">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h6m9 0a9 9 0 11-18 0 9 9 0 0118 0zm-5 5l4 2-1-3" />
+            </svg>
+        </button>
+        <div class="chatbot-window" id="chatbot-window" role="dialog" aria-modal="false" aria-label="Sakura Ramen virtual concierge" hidden>
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="font-display">Virtual Concierge</h3>
+                    <p>Live chat is coming soon.</p>
+                </div>
+                <button class="chatbot-close" type="button" aria-label="Close chat window">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message chatbot-message--bot">
+                    <span class="chatbot-avatar" aria-hidden="true">🍜</span>
+                    <div class="chatbot-bubble">
+                        Kon'nichiwa! I'm the Sakura Ramen concierge. Our interactive chat will be launching soon, but I'm here to guide you through the highlights while you explore.
+                    </div>
+                </div>
+                <div class="chatbot-message chatbot-message--note">
+                    Demo preview: conversational support will be activated after integration.
+                </div>
+            </div>
+            <div class="chatbot-footer">
+                <input class="chatbot-input" type="text" placeholder="Chat support coming soon" disabled>
+                <button class="chatbot-send" type="button" disabled>Send</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Cart Modal -->
     <div id="cart-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden">


### PR DESCRIPTION
## Summary
- add a floating chatbot preview widget to the home, menu, about, and contact pages so visitors can see the upcoming concierge
- style the widget to align with the site's palette while keeping it responsive on smaller screens
- update the shared JavaScript to handle opening, closing, and accessibility interactions for the demo chatbot

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e307fcc718832b896626d84fae4c85