### PR TITLE
Remove home page header logo and balance nav links

### DIFF
--- a/about.html
+++ b/about.html
@@ -380,7 +380,6 @@
             <div class="flex items-center justify-between">
                 <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">

--- a/contact.html
+++ b/contact.html
@@ -468,7 +468,6 @@
             <div class="flex items-center justify-between">
                 <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">

--- a/index.html
+++ b/index.html
@@ -377,12 +377,7 @@
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
             <div class="flex items-center justify-between">
-                <div class="flex items-center">
-                    <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <span class="sr-only">Sakura Ramen</span>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
+                <div class="hidden md:flex flex-1 items-center justify-evenly">
                     <a href="index.html" class="text-gray-800 hover:text-sakura-pink transition-colors font-medium">Home</a>
                     <a href="menu.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Menu</a>
                     <a href="about.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">About</a>

--- a/menu.html
+++ b/menu.html
@@ -376,7 +376,6 @@
             <div class="flex items-center justify-between">
                 <div class="flex items-center">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                    <span class="sr-only">Sakura Ramen</span>
                 </div>
                 
                 <div class="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- remove the visually exposed "Sakura Ramen" text sitting beside the header logo on the about, menu, and contact pages to match the home page header styling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ee98c8429c832bb95a770bb50b03f9