### PR TITLE
Add interactive cart with Netlify checkout bridge

### DIFF
--- a/about.html
+++ b/about.html
@@ -377,27 +377,31 @@
     <!-- Navigation -->
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center">
+            <div class="flex items-center justify-between gap-6">
+                <a href="index.html" class="hidden md:block">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                </div>
-                
+                </a>
+
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="index.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Home</a>
                     <a href="menu.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Menu</a>
                     <a href="about.html" class="text-gray-800 hover:text-sakura-pink transition-colors font-medium">About</a>
                     <a href="contact.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Contact</a>
-                    <button class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</button>
+                    <button type="button" data-cart-trigger class="relative px-5 py-2 rounded-full border border-gray-300 font-medium text-gray-700 hover:text-gray-900 hover:border-gray-400 transition">
+                        <span>Cart</span>
+                        <span data-cart-count class="ml-2 inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-[#F4C2C2] px-2 text-sm font-semibold text-gray-900" aria-live="polite">0</span>
+                    </button>
+                    <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</a>
                 </div>
-                
-                <button class="md:hidden p-2" id="mobile-menu-btn">
+
+                <button class="md:hidden p-2" id="mobile-menu-btn" aria-label="Toggle navigation">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                     </svg>
                 </button>
             </div>
         </div>
-        
+
         <!-- Mobile Menu -->
         <div class="md:hidden hidden bg-white border-t" id="mobile-menu">
             <div class="px-6 py-4 space-y-4">
@@ -405,7 +409,8 @@
                 <a href="menu.html" class="block text-gray-600">Menu</a>
                 <a href="about.html" class="block text-gray-800 font-medium">About</a>
                 <a href="contact.html" class="block text-gray-600">Contact</a>
-                <button class="btn-primary px-6 py-2 rounded-full font-medium w-full">Order Online</button>
+                <button type="button" data-cart-trigger class="w-full border border-gray-300 rounded-full py-2 font-medium text-gray-700">View Cart (<span data-cart-count>0</span>)</button>
+                <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium w-full text-center inline-block">Order Online</a>
             </div>
         </div>
     </nav>
@@ -681,5 +686,6 @@
 
     <!-- JavaScript -->
     <script src="main.js"></script>
+    <script type="module" src="./src/components/Cart.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -465,27 +465,31 @@
     <!-- Navigation -->
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center">
+            <div class="flex items-center justify-between gap-6">
+                <a href="index.html" class="hidden md:block">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                </div>
-                
+                </a>
+
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="index.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Home</a>
                     <a href="menu.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Menu</a>
                     <a href="about.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">About</a>
                     <a href="contact.html" class="text-gray-800 hover:text-sakura-pink transition-colors font-medium">Contact</a>
-                    <button class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</button>
+                    <button type="button" data-cart-trigger class="relative px-5 py-2 rounded-full border border-gray-300 font-medium text-gray-700 hover:text-gray-900 hover:border-gray-400 transition">
+                        <span>Cart</span>
+                        <span data-cart-count class="ml-2 inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-[#F4C2C2] px-2 text-sm font-semibold text-gray-900" aria-live="polite">0</span>
+                    </button>
+                    <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</a>
                 </div>
-                
-                <button class="md:hidden p-2" id="mobile-menu-btn">
+
+                <button class="md:hidden p-2" id="mobile-menu-btn" aria-label="Toggle navigation">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                     </svg>
                 </button>
             </div>
         </div>
-        
+
         <!-- Mobile Menu -->
         <div class="md:hidden hidden bg-white border-t" id="mobile-menu">
             <div class="px-6 py-4 space-y-4">
@@ -493,7 +497,8 @@
                 <a href="menu.html" class="block text-gray-600">Menu</a>
                 <a href="about.html" class="block text-gray-600">About</a>
                 <a href="contact.html" class="block text-gray-800 font-medium">Contact</a>
-                <button class="btn-primary px-6 py-2 rounded-full font-medium w-full">Order Online</button>
+                <button type="button" data-cart-trigger class="w-full border border-gray-300 rounded-full py-2 font-medium text-gray-700">View Cart (<span data-cart-count>0</span>)</button>
+                <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium w-full text-center inline-block">Order Online</a>
             </div>
         </div>
     </nav>
@@ -807,5 +812,6 @@
             setInterval(updateOpenStatus, 60000);
         });
     </script>
+    <script type="module" src="./src/components/Cart.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -376,23 +376,31 @@
     <!-- Navigation -->
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
-            <div class="flex items-center justify-between">
-                <div class="hidden md:flex flex-1 items-center justify-evenly">
+            <div class="flex items-center justify-between gap-6">
+                <a href="index.html" class="hidden md:block">
+                    <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo h-10 w-auto" />
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
                     <a href="index.html" class="text-gray-800 hover:text-sakura-pink transition-colors font-medium">Home</a>
                     <a href="menu.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Menu</a>
                     <a href="about.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">About</a>
                     <a href="contact.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Contact</a>
-                    <button class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</button>
+                    <button type="button" data-cart-trigger class="relative px-5 py-2 rounded-full border border-gray-300 font-medium text-gray-700 hover:text-gray-900 hover:border-gray-400 transition">
+                        <span>Cart</span>
+                        <span data-cart-count class="ml-2 inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-[#F4C2C2] px-2 text-sm font-semibold text-gray-900" aria-live="polite">0</span>
+                    </button>
+                    <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</a>
                 </div>
-                
-                <button class="md:hidden p-2" id="mobile-menu-btn">
+
+                <button class="md:hidden p-2" id="mobile-menu-btn" aria-label="Toggle navigation">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                     </svg>
                 </button>
             </div>
         </div>
-        
+
         <!-- Mobile Menu -->
         <div class="md:hidden hidden bg-white border-t" id="mobile-menu">
             <div class="px-6 py-4 space-y-4">
@@ -400,7 +408,8 @@
                 <a href="menu.html" class="block text-gray-600">Menu</a>
                 <a href="about.html" class="block text-gray-600">About</a>
                 <a href="contact.html" class="block text-gray-600">Contact</a>
-                <button class="btn-primary px-6 py-2 rounded-full font-medium w-full">Order Online</button>
+                <button type="button" data-cart-trigger class="w-full border border-gray-300 rounded-full py-2 font-medium text-gray-700">View Cart (<span data-cart-count>0</span>)</button>
+                <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium w-full text-center inline-block">Order Online</a>
             </div>
         </div>
     </nav>
@@ -440,59 +449,53 @@
             </div>
             
             <div class="grid md:grid-cols-3 gap-8">
-                <div class="card-hover bg-white rounded-2xl overflow-hidden shadow-lg stagger-item">
+                <div class="menu-item card-hover bg-white rounded-2xl overflow-hidden shadow-lg stagger-item" data-name="tonkotsu ramen" data-price="13.50">
                     <div class="h-64 bg-cover bg-center" style="background-image: url('./resources/ramen-tonkotsu.jpg')"></div>
-                    <div class="p-8">
-                        <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Tonkotsu Ramen</h3>
-                        <p class="text-gray-600 mb-6 leading-relaxed">
-                            Rich, creamy pork broth with fresh ramen noodles, tender pork belly, 
-                            soft-boiled egg, traditional toppings. Our signature dish.
-                        </p>
-                        <div class="flex justify-between items-center">
-                            <span class="text-2xl font-bold text-sakura-pink">$13.50</span>
-                            <button class="text-gray-600 hover:text-sakura-pink transition-colors">
-                                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
-                                </svg>
-                            </button>
+                    <div class="p-8 flex flex-col gap-6">
+                        <div>
+                            <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Tonkotsu Ramen</h3>
+                            <p class="text-gray-600 leading-relaxed">
+                                Rich, creamy pork broth with fresh ramen noodles, tender pork belly,
+                                soft-boiled egg, traditional toppings. Our signature dish.
+                            </p>
+                        </div>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <span class="text-2xl font-bold" style="color: var(--sakura-pink);">$13.50</span>
+                            <button type="button" class="btn-primary px-6 py-2 rounded-full font-semibold add-to-cart">Add to Cart</button>
                         </div>
                     </div>
                 </div>
-                
-                <div class="card-hover bg-white rounded-2xl overflow-hidden shadow-lg stagger-item">
+
+                <div class="menu-item card-hover bg-white rounded-2xl overflow-hidden shadow-lg stagger-item" data-name="appetizer platter" data-price="18.95">
                     <div class="h-64 bg-cover bg-center" style="background-image: url('./resources/starters-platter.jpg')"></div>
-                    <div class="p-8">
-                        <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Appetizer Platter</h3>
-                        <p class="text-gray-600 mb-6 leading-relaxed">
-                            A perfect start to your meal featuring our most popular starters: 
-                            edamame, spring rolls, and takoyaki balls.
-                        </p>
-                        <div class="flex justify-between items-center">
-                            <span class="text-2xl font-bold text-sakura-pink">$18.95</span>
-                            <button class="text-gray-600 hover:text-sakura-pink transition-colors">
-                                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
-                                </svg>
-                            </button>
+                    <div class="p-8 flex flex-col gap-6">
+                        <div>
+                            <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Appetizer Platter</h3>
+                            <p class="text-gray-600 leading-relaxed">
+                                A perfect start to your meal featuring our most popular starters:
+                                edamame, spring rolls, and takoyaki balls.
+                            </p>
+                        </div>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <span class="text-2xl font-bold" style="color: var(--sakura-pink);">$18.95</span>
+                            <button type="button" class="btn-primary px-6 py-2 rounded-full font-semibold add-to-cart">Add to Cart</button>
                         </div>
                     </div>
                 </div>
-                
-                <div class="card-hover bg-white rounded-2xl overflow-hidden shadow-lg stagger-item">
+
+                <div class="menu-item card-hover bg-white rounded-2xl overflow-hidden shadow-lg stagger-item" data-name="japanese fried rice" data-price="11.25">
                     <div class="h-64 bg-cover bg-center" style="background-image: url('./resources/fried-rice.jpg')"></div>
-                    <div class="p-8">
-                        <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Japanese Fried Rice</h3>
-                        <p class="text-gray-600 mb-6 leading-relaxed">
-                            Wok-tossed perfection with homemade soy sauce, fresh eggs, 
-                            scallions, and bean sprouts. A comforting classic.
-                        </p>
-                        <div class="flex justify-between items-center">
-                            <span class="text-2xl font-bold text-sakura-pink">$11.25</span>
-                            <button class="text-gray-600 hover:text-sakura-pink transition-colors">
-                                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
-                                </svg>
-                            </button>
+                    <div class="p-8 flex flex-col gap-6">
+                        <div>
+                            <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Japanese Fried Rice</h3>
+                            <p class="text-gray-600 leading-relaxed">
+                                Wok-tossed perfection with homemade soy sauce, fresh eggs,
+                                scallions, and bean sprouts. A comforting classic.
+                            </p>
+                        </div>
+                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                            <span class="text-2xl font-bold" style="color: var(--sakura-pink);">$11.25</span>
+                            <button type="button" class="btn-primary px-6 py-2 rounded-full font-semibold add-to-cart">Add to Cart</button>
                         </div>
                     </div>
                 </div>
@@ -659,5 +662,6 @@
 
     <!-- JavaScript -->
     <script src="main.js"></script>
+    <script type="module" src="./src/components/Cart.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -2,7 +2,6 @@
 // Handles all interactive functionality, animations, and user experience
 
 // Global variables
-let cart = [];
 let currentFilter = 'all';
 
 // Initialize everything when DOM is loaded
@@ -13,7 +12,6 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeSearch();
     initializeContactForm();
     initializeScrollAnimations();
-    initializeCartFunctionality();
     initializeTextAnimations();
     initializeChatbot();
 });
@@ -312,60 +310,6 @@ function initializeScrollAnimations() {
     }
 }
 
-// Cart functionality
-function initializeCartFunctionality() {
-    const addToCartButtons = document.querySelectorAll('.add-to-cart');
-    const cartModal = document.getElementById('cart-modal');
-    const closeCartModal = document.getElementById('close-cart-modal');
-    
-    addToCartButtons.forEach(button => {
-        button.addEventListener('click', function(e) {
-            e.preventDefault();
-            showCartModal();
-        });
-    });
-    
-    if (closeCartModal) {
-        closeCartModal.addEventListener('click', function() {
-            hideCartModal();
-        });
-    }
-    
-    if (cartModal) {
-        cartModal.addEventListener('click', function(e) {
-            if (e.target === cartModal) {
-                hideCartModal();
-            }
-        });
-    }
-}
-
-function showCartModal() {
-    const cartModal = document.getElementById('cart-modal');
-    if (cartModal) {
-        cartModal.classList.remove('hidden');
-        document.body.style.overflow = 'hidden';
-        
-        if (typeof anime !== 'undefined') {
-            anime({
-                targets: cartModal.querySelector('.bg-white'),
-                scale: [0.8, 1],
-                opacity: [0, 1],
-                duration: 300,
-                easing: 'easeOutExpo'
-            });
-        }
-    }
-}
-
-function hideCartModal() {
-    const cartModal = document.getElementById('cart-modal');
-    if (cartModal) {
-        cartModal.classList.add('hidden');
-        document.body.style.overflow = 'auto';
-    }
-}
-
 // Contact form functionality
 function initializeContactForm() {
     const contactForm = document.getElementById('contact-form');
@@ -490,7 +434,7 @@ document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape') {
         const openModals = document.querySelectorAll('.fixed:not(.hidden)');
         openModals.forEach(modal => {
-            if (modal.id === 'cart-modal' || modal.id === 'success-modal') {
+            if (modal.id === 'success-modal') {
                 modal.classList.add('hidden');
                 document.body.style.overflow = 'auto';
             }

--- a/menu.html
+++ b/menu.html
@@ -367,33 +367,37 @@
 <body>
     <!-- Coming Soon Banner -->
     <div class="coming-soon-banner">
-        🚀 Online Ordering Coming Soon! Call 407-217-2705 to place orders
+        ✨ Build your order below, then checkout to complete payment on our official partner site.
     </div>
 
     <!-- Navigation -->
     <nav class="glass-nav fixed top-0 left-0 right-0 z-50">
         <div class="max-w-6xl mx-auto px-6 py-4">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center">
+            <div class="flex items-center justify-between gap-6">
+                <a href="index.html" class="hidden md:block">
                     <img src="./resources/logo.png" alt="Sakura Ramen Logo" class="logo" />
-                </div>
-                
+                </a>
+
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="index.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Home</a>
                     <a href="menu.html" class="text-gray-800 hover:text-sakura-pink transition-colors font-medium">Menu</a>
                     <a href="about.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">About</a>
                     <a href="contact.html" class="text-gray-600 hover:text-sakura-pink transition-colors font-medium">Contact</a>
-                    <button class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</button>
+                    <button type="button" data-cart-trigger class="relative px-5 py-2 rounded-full border border-gray-300 font-medium text-gray-700 hover:text-gray-900 hover:border-gray-400 transition">
+                        <span>Cart</span>
+                        <span data-cart-count class="ml-2 inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-[#F4C2C2] px-2 text-sm font-semibold text-gray-900" aria-live="polite">0</span>
+                    </button>
+                    <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium">Order Online</a>
                 </div>
-                
-                <button class="md:hidden p-2" id="mobile-menu-btn">
+
+                <button class="md:hidden p-2" id="mobile-menu-btn" aria-label="Toggle navigation">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                     </svg>
                 </button>
             </div>
         </div>
-        
+
         <!-- Mobile Menu -->
         <div class="md:hidden hidden bg-white border-t" id="mobile-menu">
             <div class="px-6 py-4 space-y-4">
@@ -401,7 +405,8 @@
                 <a href="menu.html" class="block text-gray-800 font-medium">Menu</a>
                 <a href="about.html" class="block text-gray-600">About</a>
                 <a href="contact.html" class="block text-gray-600">Contact</a>
-                <button class="btn-primary px-6 py-2 rounded-full font-medium w-full">Order Online</button>
+                <button type="button" data-cart-trigger class="w-full border border-gray-300 rounded-full py-2 font-medium text-gray-700">View Cart (<span data-cart-count>0</span>)</button>
+                <a href="https://order.sakuraramen208.com/" target="_blank" rel="noopener" class="btn-primary px-6 py-2 rounded-full font-medium w-full text-center inline-block">Order Online</a>
             </div>
         </div>
     </nav>
@@ -691,25 +696,8 @@
         </div>
     </div>
 
-    <!-- Cart Modal -->
-    <div id="cart-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden">
-        <div class="flex items-center justify-center min-h-screen p-4">
-            <div class="bg-white rounded-2xl p-8 max-w-md w-full">
-                <div class="text-center">
-                    <div class="w-16 h-16 bg-sakura-pink rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                        </svg>
-                    </div>
-                    <h3 class="font-display text-2xl font-bold mb-4 text-charcoal">Coming Soon!</h3>
-                    <p class="text-gray-600 mb-6">Our online ordering system is currently in development. Please call us at 407-217-2705 to place your order.</p>
-                    <button id="close-cart-modal" class="btn-primary px-8 py-3 rounded-full font-medium">Got it!</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- JavaScript -->
     <script src="main.js"></script>
+    <script type="module" src="./src/components/Cart.js"></script>
 </body>
 </html>

--- a/netlify/functions/sendOrderToExternal.js
+++ b/netlify/functions/sendOrderToExternal.js
@@ -1,0 +1,77 @@
+export const handler = async (event) => {
+    if (event.httpMethod !== 'POST') {
+        return {
+            statusCode: 405,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: 'Method Not Allowed' })
+        };
+    }
+
+    try {
+        const payload = JSON.parse(event.body || '{}');
+        const { items = [], subtotal = 0, totalItems = 0, orderNote = '', submittedAt } = payload;
+
+        if (!Array.isArray(items) || items.length === 0) {
+            return {
+                statusCode: 400,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: 'Cart is empty' })
+            };
+        }
+
+        const sanitizedItems = items.map(item => ({
+            id: item.id,
+            name: item.name,
+            quantity: Number(item.quantity) || 0,
+            price: Number(item.price) || 0,
+            notes: item.notes || ''
+        }));
+
+        const orderPayload = {
+            items: sanitizedItems,
+            subtotal: Number(subtotal) || 0,
+            totalItems: Number(totalItems) || sanitizedItems.reduce((sum, item) => sum + item.quantity, 0),
+            orderNote,
+            submittedAt: submittedAt || new Date().toISOString()
+        };
+
+        const webhookUrl = process.env.ORDER_WEBHOOK_URL;
+        let forwarded = false;
+        let webhookResponse = null;
+
+        if (webhookUrl) {
+            try {
+                const response = await fetch(webhookUrl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(orderPayload)
+                });
+
+                forwarded = response.ok;
+                webhookResponse = {
+                    status: response.status,
+                    statusText: response.statusText
+                };
+            } catch (error) {
+                console.error('Failed to forward order to webhook:', error);
+            }
+        }
+
+        return {
+            statusCode: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                forwarded,
+                webhookResponse,
+                redirectUrl: 'https://order.sakuraramen208.com/'
+            })
+        };
+    } catch (error) {
+        console.error('Order forwarding error', error);
+        return {
+            statusCode: 500,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: 'Unable to process order' })
+        };
+    }
+};

--- a/src/components/Cart.js
+++ b/src/components/Cart.js
@@ -1,0 +1,472 @@
+import {
+    addItemToCart,
+    clearCart,
+    getOrderSummary,
+    initializeCartStorage,
+    removeCartItem,
+    setCartItemNote,
+    subscribeToCart,
+    updateCartItemQuantity
+} from '../utils/cartLogic.js';
+
+const ORDER_PORTAL_URL = 'https://order.sakuraramen208.com/';
+const ORDER_NOTE_KEY = 'sakura-ramen-order-note';
+let drawerElement;
+let overlayElement;
+let panelElement;
+let statusElement;
+let orderNoteInput;
+let checkoutButton;
+let cartItemsContainer;
+let emptyStateElement;
+let subtotalElement;
+let clearButton;
+let isAnimating = false;
+
+function ready(callback) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback);
+    } else {
+        callback();
+    }
+}
+
+function ensureDrawer() {
+    if (drawerElement) {
+        return;
+    }
+
+    drawerElement = document.createElement('div');
+    drawerElement.id = 'cart-drawer';
+    drawerElement.className = 'fixed inset-0 z-[70] pointer-events-none';
+
+    drawerElement.innerHTML = `
+        <div data-cart-overlay class="absolute inset-0 bg-black/40 opacity-0 transition-opacity duration-300"></div>
+        <aside data-cart-panel class="absolute right-0 top-0 h-full w-full max-w-md bg-white shadow-2xl translate-x-full transition-transform duration-300 flex flex-col">
+            <header class="px-6 py-5 border-b border-gray-100 flex items-start justify-between gap-4">
+                <div>
+                    <h2 class="font-display text-2xl font-semibold text-gray-900">Your Order</h2>
+                    <p class="text-sm text-gray-500">Review selections and finish checkout with our ordering partner.</p>
+                </div>
+                <button type="button" data-cart-close class="w-10 h-10 rounded-full border border-gray-200 text-gray-500 hover:text-gray-800 hover:border-gray-300 transition flex items-center justify-center" aria-label="Close cart">
+                    <span class="text-xl leading-none">×</span>
+                </button>
+            </header>
+            <div class="flex-1 overflow-y-auto px-6 py-4" data-cart-body>
+                <div data-cart-empty class="text-center text-gray-500 py-12">
+                    <p class="font-medium text-gray-600 mb-2">Your cart is empty</p>
+                    <p class="text-sm">Explore the menu and add dishes to begin.</p>
+                </div>
+                <div data-cart-items class="space-y-6"></div>
+            </div>
+            <div class="px-6 py-5 border-t border-gray-100 space-y-4 bg-white">
+                <div class="flex items-center justify-between text-gray-700">
+                    <span class="font-medium">Subtotal</span>
+                    <span data-cart-subtotal class="font-semibold text-gray-900">$0.00</span>
+                </div>
+                <label class="block">
+                    <span class="text-xs uppercase tracking-wide text-gray-400">Order note</span>
+                    <textarea data-order-note class="mt-2 w-full border border-gray-200 rounded-xl p-3 text-sm focus:outline-none focus:ring-2 focus:ring-[#F4C2C2] focus:border-[#F4C2C2] transition" rows="3" placeholder="Share pickup details or dietary notes (optional)"></textarea>
+                </label>
+                <p class="text-xs text-gray-500 leading-relaxed">We will securely forward these details to Sakura Ramen's ordering portal and open their checkout so you can confirm payment.</p>
+                <div data-cart-status class="text-sm font-medium"></div>
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <button type="button" data-cart-clear class="flex-1 border border-gray-300 rounded-full py-3 font-medium text-gray-600 hover:text-gray-800 hover:border-gray-400 transition">Clear Cart</button>
+                    <button type="button" data-cart-checkout class="flex-1 btn-primary px-6 py-3 rounded-full font-semibold shadow-lg hover:shadow-xl transition">Checkout</button>
+                </div>
+            </div>
+        </aside>
+    `;
+
+    document.body.appendChild(drawerElement);
+    overlayElement = drawerElement.querySelector('[data-cart-overlay]');
+    panelElement = drawerElement.querySelector('[data-cart-panel]');
+    statusElement = drawerElement.querySelector('[data-cart-status]');
+    orderNoteInput = drawerElement.querySelector('[data-order-note]');
+    checkoutButton = drawerElement.querySelector('[data-cart-checkout]');
+    cartItemsContainer = drawerElement.querySelector('[data-cart-items]');
+    emptyStateElement = drawerElement.querySelector('[data-cart-empty]');
+    subtotalElement = drawerElement.querySelector('[data-cart-subtotal]');
+    clearButton = drawerElement.querySelector('[data-cart-clear]');
+
+    const savedNote = loadOrderNote();
+    if (savedNote && orderNoteInput) {
+        orderNoteInput.value = savedNote;
+    }
+}
+
+function openCart() {
+    if (!drawerElement || isAnimating) {
+        return;
+    }
+
+    drawerElement.classList.remove('pointer-events-none');
+    requestAnimationFrame(() => {
+        overlayElement.style.opacity = '1';
+        panelElement.style.transform = 'translateX(0)';
+        document.body.style.overflow = 'hidden';
+    });
+}
+
+function closeCart() {
+    if (!drawerElement || isAnimating) {
+        return;
+    }
+
+    isAnimating = true;
+    overlayElement.style.opacity = '0';
+    panelElement.style.transform = 'translateX(100%)';
+
+    setTimeout(() => {
+        drawerElement.classList.add('pointer-events-none');
+        document.body.style.overflow = '';
+        isAnimating = false;
+    }, 300);
+}
+
+function formatCurrency(amount) {
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD'
+    }).format(amount);
+}
+
+function updateCartBadges(cart) {
+    const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
+    const countElements = document.querySelectorAll('[data-cart-count]');
+
+    countElements.forEach(element => {
+        element.textContent = totalItems;
+    });
+}
+
+function toggleEmptyState(cart) {
+    if (!cartItemsContainer || !emptyStateElement) {
+        return;
+    }
+
+    if (cart.length === 0) {
+        emptyStateElement.classList.remove('hidden');
+        cartItemsContainer.classList.add('hidden');
+    } else {
+        emptyStateElement.classList.add('hidden');
+        cartItemsContainer.classList.remove('hidden');
+    }
+}
+
+function bindItemControls(container) {
+    container.querySelectorAll('[data-cart-remove]').forEach(button => {
+        button.addEventListener('click', () => {
+            const itemId = button.getAttribute('data-cart-remove');
+            removeCartItem(itemId);
+        });
+    });
+
+    container.querySelectorAll('[data-cart-increment]').forEach(button => {
+        button.addEventListener('click', () => {
+            const itemId = button.getAttribute('data-cart-increment');
+            const currentQuantity = Number(button.getAttribute('data-quantity')) || 0;
+            updateCartItemQuantity(itemId, currentQuantity + 1);
+        });
+    });
+
+    container.querySelectorAll('[data-cart-decrement]').forEach(button => {
+        button.addEventListener('click', () => {
+            const itemId = button.getAttribute('data-cart-decrement');
+            const currentQuantity = Number(button.getAttribute('data-quantity')) || 0;
+            const nextQuantity = currentQuantity - 1;
+            if (nextQuantity < 1) {
+                removeCartItem(itemId);
+            } else {
+                updateCartItemQuantity(itemId, nextQuantity);
+            }
+        });
+    });
+
+    container.querySelectorAll('[data-cart-item-note]').forEach(textarea => {
+        textarea.addEventListener('input', event => {
+            const itemId = textarea.getAttribute('data-cart-item-note');
+            setCartItemNote(itemId, event.target.value);
+        });
+    });
+}
+
+function renderCartItems(cart) {
+    if (!cartItemsContainer) {
+        return;
+    }
+
+    cartItemsContainer.innerHTML = '';
+
+    cart.forEach(item => {
+        const itemElement = document.createElement('div');
+        itemElement.className = 'border border-gray-100 rounded-2xl p-4 shadow-sm';
+        itemElement.setAttribute('data-cart-item', item.id);
+        itemElement.innerHTML = `
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <h3 class="font-semibold text-gray-900">${item.name}</h3>
+                    ${item.description ? `<p class="text-sm text-gray-500 mt-1">${item.description}</p>` : ''}
+                    <p class="text-xs text-gray-400 mt-2">${formatCurrency(item.price)} each</p>
+                </div>
+                <button type="button" class="text-gray-400 hover:text-red-500 transition" aria-label="Remove ${item.name}" data-cart-remove="${item.id}">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="mt-4 flex items-center justify-between gap-4">
+                <div class="flex items-center bg-[#F8F8F8] rounded-full px-3 py-2">
+                    <button type="button" class="px-2 text-xl text-gray-500 hover:text-gray-800 transition" aria-label="Decrease quantity" data-cart-decrement="${item.id}" data-quantity="${item.quantity}">−</button>
+                    <span class="px-4 text-base font-medium text-gray-800">${item.quantity}</span>
+                    <button type="button" class="px-2 text-xl text-gray-500 hover:text-gray-800 transition" aria-label="Increase quantity" data-cart-increment="${item.id}" data-quantity="${item.quantity}">+</button>
+                </div>
+                <span class="font-semibold text-gray-900">${formatCurrency(item.price * item.quantity)}</span>
+            </div>
+            <label class="mt-4 block">
+                <span class="text-xs uppercase tracking-wide text-gray-400">Notes</span>
+                <textarea class="mt-2 w-full border border-gray-200 rounded-xl p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-[#F4C2C2] focus:border-[#F4C2C2] transition" data-cart-item-note="${item.id}" rows="2" placeholder="Extra noodles, sauce on the side, etc.">${item.notes || ''}</textarea>
+            </label>
+        `;
+
+        cartItemsContainer.appendChild(itemElement);
+    });
+
+    bindItemControls(cartItemsContainer);
+}
+
+function updateSubtotal(cart) {
+    if (!subtotalElement) {
+        return;
+    }
+
+    const subtotal = cart.reduce((total, item) => total + item.price * item.quantity, 0);
+    subtotalElement.textContent = formatCurrency(subtotal);
+}
+
+function setupTriggers() {
+    const triggers = document.querySelectorAll('[data-cart-trigger]');
+    triggers.forEach(trigger => {
+        trigger.addEventListener('click', event => {
+            event.preventDefault();
+            ensureDrawer();
+            openCart();
+        });
+    });
+}
+
+function setupCloseInteractions() {
+    if (!drawerElement) {
+        return;
+    }
+
+    drawerElement.querySelectorAll('[data-cart-close]').forEach(button => {
+        button.addEventListener('click', () => closeCart());
+    });
+
+    if (overlayElement) {
+        overlayElement.addEventListener('click', () => closeCart());
+    }
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && drawerElement && !drawerElement.classList.contains('pointer-events-none')) {
+            closeCart();
+        }
+    });
+}
+
+function getMenuItemDetails(button) {
+    const card = button.closest('.menu-item') || button.closest('[data-menu-item]');
+    if (!card) {
+        return null;
+    }
+
+    const name = (card.dataset.name || card.querySelector('h3, h4, h5')?.textContent || '').trim();
+    const description = (card.dataset.description || card.querySelector('p')?.textContent || '').trim();
+
+    let priceValue = card.dataset.price;
+    if (!priceValue) {
+        const priceElement = card.querySelector('[data-price], .price, span');
+        if (priceElement) {
+            const priceMatch = priceElement.textContent.match(/[\d.,]+/);
+            priceValue = priceMatch ? priceMatch[0] : '0';
+        }
+    }
+
+    const numericPrice = parseFloat(String(priceValue).replace(/,/g, '')) || 0;
+    const id = card.dataset.itemId || undefined;
+
+    return {
+        id,
+        name,
+        description,
+        price: numericPrice
+    };
+}
+
+function setupAddToCartButtons() {
+    const buttons = document.querySelectorAll('.add-to-cart');
+
+    buttons.forEach(button => {
+        if (button.dataset.cartReady === 'true') {
+            return;
+        }
+
+        button.dataset.cartReady = 'true';
+        button.addEventListener('click', event => {
+            event.preventDefault();
+            ensureDrawer();
+            const details = getMenuItemDetails(button);
+            if (!details) {
+                return;
+            }
+
+            addItemToCart(details);
+            if (statusElement) {
+                statusElement.textContent = `${details.name} added to cart.`;
+                statusElement.className = 'text-sm font-medium text-gray-700';
+            }
+            openCart();
+        });
+    });
+}
+
+function saveOrderNote(note) {
+    try {
+        window.localStorage.setItem(ORDER_NOTE_KEY, note);
+    } catch (error) {
+        console.warn('Unable to persist order note', error);
+    }
+}
+
+function loadOrderNote() {
+    try {
+        return window.localStorage.getItem(ORDER_NOTE_KEY) || '';
+    } catch (error) {
+        return '';
+    }
+}
+
+async function forwardCartToOrderingPortal(cartPayload) {
+    const response = await fetch('/.netlify/functions/sendOrderToExternal', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(cartPayload)
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Unable to forward order to restaurant');
+    }
+
+    return response.json();
+}
+
+async function handleCheckout(cart) {
+    if (!cart.length || !checkoutButton) {
+        return;
+    }
+
+    checkoutButton.disabled = true;
+    checkoutButton.textContent = 'Sending…';
+    statusElement.textContent = 'Preparing your order…';
+    statusElement.className = 'text-sm font-medium text-gray-500';
+
+    const orderNote = orderNoteInput ? orderNoteInput.value.trim() : '';
+    saveOrderNote(orderNote);
+
+    const payload = {
+        ...getOrderSummary(),
+        orderNote,
+        submittedAt: new Date().toISOString()
+    };
+
+    try {
+        const response = await forwardCartToOrderingPortal(payload);
+        statusElement.textContent = 'Order details sent! We opened our partner site so you can confirm checkout.';
+        statusElement.className = 'text-sm font-medium text-green-600';
+
+        window.open(ORDER_PORTAL_URL, '_blank', 'noopener');
+
+        if (response && response.forwarded === false) {
+            statusElement.textContent += ' (Heads up: automatic forwarding is disabled, so please review your selections manually.)';
+        }
+    } catch (error) {
+        console.error(error);
+        statusElement.textContent = 'We could not reach the ordering portal automatically. Please try again or order directly.';
+        statusElement.className = 'text-sm font-medium text-red-600';
+    } finally {
+        checkoutButton.disabled = false;
+        checkoutButton.textContent = 'Checkout';
+    }
+}
+
+function setupCheckout() {
+    if (!checkoutButton) {
+        return;
+    }
+
+    checkoutButton.addEventListener('click', event => {
+        event.preventDefault();
+        const summary = getOrderSummary();
+        if (!summary.items.length) {
+            statusElement.textContent = 'Add at least one item before checking out.';
+            statusElement.className = 'text-sm font-medium text-red-500';
+            return;
+        }
+
+        handleCheckout(summary.items);
+    });
+}
+
+function setupClearButton() {
+    if (!clearButton) {
+        return;
+    }
+
+    clearButton.addEventListener('click', () => {
+        clearCart();
+        if (orderNoteInput) {
+            orderNoteInput.value = '';
+        }
+        saveOrderNote('');
+        if (statusElement) {
+            statusElement.textContent = 'Cart cleared.';
+            statusElement.className = 'text-sm font-medium text-gray-500';
+        }
+    });
+}
+
+function initialise() {
+    initializeCartStorage();
+    ensureDrawer();
+    setupTriggers();
+    setupCloseInteractions();
+    setupAddToCartButtons();
+    setupCheckout();
+    setupClearButton();
+
+    if (orderNoteInput) {
+        orderNoteInput.addEventListener('input', event => {
+            saveOrderNote(event.target.value);
+        });
+    }
+
+    subscribeToCart(cart => {
+        updateCartBadges(cart);
+        toggleEmptyState(cart);
+        renderCartItems(cart);
+        updateSubtotal(cart);
+
+        if (!cart.length && statusElement) {
+            statusElement.textContent = '';
+            statusElement.className = 'text-sm font-medium text-gray-500';
+        }
+    });
+}
+
+ready(initialise);
+
+export { initialise as initializeCartUI };

--- a/src/utils/cartLogic.js
+++ b/src/utils/cartLogic.js
@@ -1,0 +1,225 @@
+const STORAGE_KEY = 'sakura-ramen-cart-v1';
+let cartState = [];
+let initialized = false;
+const subscribers = new Set();
+
+function hasLocalStorage() {
+    try {
+        const testKey = '__sakura_cart_test__';
+        window.localStorage.setItem(testKey, '1');
+        window.localStorage.removeItem(testKey);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function loadFromStorage() {
+    if (typeof window === 'undefined' || !hasLocalStorage()) {
+        return [];
+    }
+
+    try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.map(item => ({
+            id: item.id,
+            name: item.name,
+            description: item.description || '',
+            price: Number(item.price) || 0,
+            quantity: Number(item.quantity) || 1,
+            notes: item.notes || ''
+        })).filter(item => item.name);
+    } catch (error) {
+        console.warn('Unable to read stored cart data', error);
+        return [];
+    }
+}
+
+function persistToStorage() {
+    if (typeof window === 'undefined' || !hasLocalStorage()) {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(cartState));
+    } catch (error) {
+        console.warn('Unable to persist cart data', error);
+    }
+}
+
+function notifySubscribers() {
+    const snapshot = getCart();
+    subscribers.forEach(callback => {
+        try {
+            callback(snapshot);
+        } catch (error) {
+            console.error('Cart subscription callback failed', error);
+        }
+    });
+
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('sakura-cart:updated', { detail: { cart: snapshot } }));
+    }
+}
+
+function ensureInitialized() {
+    if (initialized) {
+        return;
+    }
+
+    cartState = loadFromStorage();
+    initialized = true;
+}
+
+function normaliseId(name, price, providedId) {
+    if (providedId) {
+        return providedId;
+    }
+
+    const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+    const priceSuffix = Number(price) ? `-${Math.round(Number(price) * 100)}` : '';
+    return `${slug}${priceSuffix}`;
+}
+
+export function initializeCartStorage() {
+    ensureInitialized();
+    persistToStorage();
+    notifySubscribers();
+    return getCart();
+}
+
+export function getCart() {
+    ensureInitialized();
+    return cartState.map(item => ({ ...item }));
+}
+
+export function getCartItemCount() {
+    return getCart().reduce((total, item) => total + item.quantity, 0);
+}
+
+export function getCartSubtotal() {
+    return getCart().reduce((total, item) => total + item.price * item.quantity, 0);
+}
+
+export function addItemToCart({ id, name, description = '', price, quantity = 1, notes = '' }) {
+    ensureInitialized();
+
+    if (!name) {
+        return getCart();
+    }
+
+    const numericPrice = Number(price) || 0;
+    const itemId = normaliseId(name, numericPrice, id);
+    const existingItem = cartState.find(item => item.id === itemId);
+
+    if (existingItem) {
+        existingItem.quantity += quantity;
+        if (notes) {
+            existingItem.notes = notes;
+        }
+    } else {
+        cartState.push({
+            id: itemId,
+            name,
+            description,
+            price: numericPrice,
+            quantity,
+            notes
+        });
+    }
+
+    persistToStorage();
+    notifySubscribers();
+    return getCart();
+}
+
+export function updateCartItemQuantity(id, quantity) {
+    ensureInitialized();
+    const target = cartState.find(item => item.id === id);
+
+    if (!target) {
+        return getCart();
+    }
+
+    const nextQuantity = Number(quantity);
+
+    if (Number.isNaN(nextQuantity) || nextQuantity < 1) {
+        removeCartItem(id);
+        return getCart();
+    }
+
+    target.quantity = Math.floor(nextQuantity);
+    persistToStorage();
+    notifySubscribers();
+    return getCart();
+}
+
+export function removeCartItem(id) {
+    ensureInitialized();
+    cartState = cartState.filter(item => item.id !== id);
+    persistToStorage();
+    notifySubscribers();
+    return getCart();
+}
+
+export function setCartItemNote(id, note) {
+    ensureInitialized();
+    const target = cartState.find(item => item.id === id);
+    if (!target) {
+        return getCart();
+    }
+
+    target.notes = note;
+    persistToStorage();
+    notifySubscribers();
+    return getCart();
+}
+
+export function clearCart() {
+    ensureInitialized();
+    cartState = [];
+    persistToStorage();
+    notifySubscribers();
+    return getCart();
+}
+
+export function subscribeToCart(callback) {
+    if (typeof callback !== 'function') {
+        return () => {};
+    }
+
+    ensureInitialized();
+    subscribers.add(callback);
+
+    // Immediately provide current state
+    try {
+        callback(getCart());
+    } catch (error) {
+        console.error('Cart subscription callback failed during registration', error);
+    }
+
+    return () => {
+        subscribers.delete(callback);
+    };
+}
+
+export function getOrderSummary() {
+    const items = getCart();
+    const subtotal = items.reduce((total, item) => total + item.price * item.quantity, 0);
+    const totalItems = items.reduce((total, item) => total + item.quantity, 0);
+
+    return {
+        items,
+        subtotal,
+        totalItems
+    };
+}


### PR DESCRIPTION
## Summary
- build a reusable cart logic module with localStorage persistence and event subscriptions, plus a Tailwind-styled drawer UI to manage quantities, notes, and checkout handoff
- add Add to Cart actions to the homepage highlights and existing menu cards while surfacing cart entry points in the global navigation across pages
- create a Netlify function that forwards order payloads to an optional webhook before redirecting guests to the external ordering portal

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68fbb1d2fef8832a92bacdad109483d3